### PR TITLE
Run clean feature added & fixed noDependencies argument typo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,13 +20,18 @@ Simple Example:
 
 ```javascript
 
-let {restore, build, test, pack, publish} = require('gulp-dotnet-cli');
+let {clean, restore, build, test, pack, publish, run} = require('gulp-dotnet-cli');
 let gulp = require('gulp');
+//clean
+gulp.task('clean', ()=>{
+    return gulp.src('**/*.csproj', {read: false})
+            .pipe(clean());
+});
 //restore nuget packages
 gulp.task('restore', ()=>{
     return gulp.src('**/*.csproj', {read: false})
             .pipe(restore());
-})
+});
 //compile
 gulp.task('build', ['restore'], ()=>{
                     //this could be **/*.sln if you wanted to build solutions
@@ -42,7 +47,12 @@ gulp.task('test', ['build'], ()=>{
 gulp.task('publish', ['test'], ()=>{
     return gulp.src('src/TestWebProject.csproj', {read: false})
                 .pipe(publish({configuration: 'Release'}));
-})
+});
+//run
+gulp.task('run', ()=>{
+    return gulp.src('src/TestWebProject.csproj', {read: false})
+            .pipe(run());
+});
 
 ```
 
@@ -51,15 +61,20 @@ More Complicated example:
 
 ```javascript
 
-let {restore, build, test, pack, publish} = require('gulp-dotnet-cli');
+let {clean, restore, build, test, pack, publish, run} = require('gulp-dotnet-cli');
 let version = `1.3.` + (process.env.BUILD_NUMBER || '0');
 let configuration = process.env.BUILD_CONFIGURATION || 'Release';
 let gulp = require('gulp');
+//clean
+gulp.task('clean', ()=>{
+    return gulp.src('**/*.csproj', {read: false})
+            .pipe(clean());
+});
 //restore nuget packages
 gulp.task('restore', ()=>{
     return gulp.src('**/*.csproj', {read: false})
             .pipe(restore());
-})
+});
 //compile
 gulp.task('build', ['restore'], ()=>{
                     //this could be **/*.sln if you wanted to build solutions
@@ -75,7 +90,7 @@ gulp.task('test', ['build'], ()=>{
 gulp.task('publish', ['test'], ()=>{
     return gulp.src('src/TestWebProject.csproj', {read: false})
                 .pipe(publish({configuration: configuration, version: version}));
-})
+});
 //convert a project to a nuget package
 gulp.task('pack', ['build'], ()=>{
     return gulp.src('**/TestLibrary.csproj', {read: false})
@@ -90,6 +105,11 @@ gulp.task('push', ['pack'], ()=>{
                 .pipe(push({
                     apiKey: process.env.NUGET_API_KEY, 
                     source: 'https://myget.org/f/myfeedurl'}));
+});
+//run
+gulp.task('run', ()=>{
+    return gulp.src('src/TestWebProject.csproj', {read: false})
+                .pipe(run());
 });
 
 ```

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -6,3 +6,5 @@ The api docs are broken up by action. All paramters are objects with key/values,
 * [push](push.md)
 * [restore](restore.md)
 * [test](test.md)
+* [clean](clean.md)
+* [run](run.md)

--- a/docs/build.md
+++ b/docs/build.md
@@ -49,7 +49,7 @@ The [build model](/lib/models/BuildModel.js) contains the actual model we valida
 
 > Disables incremental build.
 
-#### noDepenencies
+#### noDependencies
 
 * type: `bool`
 

--- a/docs/clean.md
+++ b/docs/clean.md
@@ -1,0 +1,67 @@
+# Clean
+
+The clean module is responsible for running `dotnet clean` or essentially calling the compiler. You can get more help by running `dotnet clean --help`
+
+```js
+let {clean} = require('gulp-dotnet-cli');
+
+```
+
+
+## Options
+
+The [build model](/lib/models/BuildModel.js) contains the actual model we validate against
+
+
+#### output 
+
+* type: `string`
+
+> Output directory in which to place built artifacts
+
+#### framework
+
+* type: `string`
+
+> Target framework to build for. The target framework has to be specified in the project file.
+
+#### runtime
+
+* type: `string`
+
+> Target runtime to build for. The default is to build a portable application.
+
+#### configuration 
+
+* type: `string`
+
+> Configuration to use for building the project. Default for most projects is  "Debug"
+
+#### verbosity 
+
+* type: `string`
+
+**valid values:** 'quiet', 'minimal', 'normal', 'detailed', 'diagnostic'
+
+> sets the console verbosity
+
+#### version 
+
+* type: `string`
+
+> Sets the $(Version) property in msbuild
+
+
+#### msbuildArgs
+
+* type: `Array<string>`
+
+> Any extra options that should be passed to MSBuild. See dotnet msbuild -h for available options
+
+#### echo
+
+* type: `bool`
+
+* default: false
+
+> Logs the command we run to the console

--- a/docs/run.md
+++ b/docs/run.md
@@ -1,0 +1,103 @@
+# Run
+
+The run module is responsible for running `dotnet run` or essentially calling the compiler. You can get more help by running `dotnet run --help`
+
+```js
+let {run} = require('gulp-dotnet-cli');
+
+```
+
+
+## Options
+
+The [run model](/lib/models/RunModel.js) contains the actual model we validate against
+
+
+#### output 
+
+* type: `string`
+
+> Output directory in which to place built artifacts
+
+#### framework
+
+* type: `string`
+
+> Target framework to build for. The target framework has to be specified in the project file.
+
+#### runtime
+
+* type: `string`
+
+> Target runtime to build for. The default is to build a portable application.
+
+#### configuration 
+
+* type: `string`
+
+> Configuration to use for building the project. Default for most projects is  "Debug"
+
+#### launchProfile
+
+* type: `string`
+
+> The name of the launch profile (if any) to use when launching the application.
+
+#### noLaunchProfile
+
+* type: `string`
+
+> Do not attempt to use launchSettings.json to configure the application.
+
+#### noBuild
+
+* type: `string`
+
+> Skip building the project prior to running. By default, the project will be built.
+
+#### noRestore
+
+* type: `string`
+
+> Does not do an implicit restore when executing the command.
+
+#### noDependencies
+
+* type: `string`
+
+> Set this flag to ignore project to project references and only restore the root project.
+
+#### force
+
+* type: `string`
+
+> Set this flag to force all dependencies to be resolved even if the last restore was successful. This is equivalent to deleting project.assets.json.
+    
+#### verbosity 
+
+* type: `string`
+
+**valid values:** 'quiet', 'minimal', 'normal', 'detailed', 'diagnostic'
+
+> sets the console verbosity
+
+#### version 
+
+* type: `string`
+
+> Sets the $(Version) property in msbuild
+
+
+#### msbuildArgs
+
+* type: `Array<string>`
+
+> Any extra options that should be passed to MSBuild. See dotnet msbuild -h for available options
+
+#### echo
+
+* type: `bool`
+
+* default: false
+
+> Logs the command we run to the console

--- a/lib/builders/buildArgBuilder.js
+++ b/lib/builders/buildArgBuilder.js
@@ -26,7 +26,7 @@ let build = (value) => {
     if (value.noIncremental) {
         args = args.concat(['--no-incremental']);
     }
-    if (value.noDepenencies) {
+    if (value.noDependencies) {
         args = args.concat(['--no-dependencies']);
     }
     if (value.verbosity) {

--- a/lib/builders/cleanArgBuilder.js
+++ b/lib/builders/cleanArgBuilder.js
@@ -1,0 +1,35 @@
+
+/**
+ * calculates clean arguments
+ * @param {CleanModel} value - the value to clean arguments off of.
+ */
+let clean = (value) => {
+    let args = [];
+    if(!value){
+        return args;
+    }
+    if (value.output) {
+        args = args.concat(['--output', value.output]);
+    }
+    if (value.framework) {
+        args = args.concat(['--framework', value.framework]);
+    }
+    if (value.runtime) {
+        args = args.concat(['--runtime', value.runtime]);
+    }
+    if (value.configuration) {
+        args = args.concat(['--configuration', value.configuration]);
+    }    
+    if (value.verbosity) {
+        args = args.concat(['--verbosity', value.verbosity]);
+    }
+    if (value.msbuildArgs) {
+        args = args.concat(value.msbuildArgs);
+    }
+    if (value.version) {
+        args = args.concat(`/p:Version=${value.version}`);
+    }
+    return args;
+};
+
+module.exports = clean;

--- a/lib/builders/restoreArgBuilder.js
+++ b/lib/builders/restoreArgBuilder.js
@@ -25,7 +25,7 @@ module.exports = (value) => {
     if (value.noIncremental) {
         args = args.concat(['--no-incremental']);
     }
-    if (value.noDepenencies) {
+    if (value.noDependencies) {
         args = args.concat(['--no-dependencies']);
     }
     if (value.verbosity) {

--- a/lib/builders/runArgBuilder.js
+++ b/lib/builders/runArgBuilder.js
@@ -1,0 +1,53 @@
+
+/**
+ * calculates run arguments
+ * @param {RunModel} value - the value to run arguments off of.
+ */
+let run = (value) => {
+    let args = [];
+    if(!value){
+        return args;
+    }    
+    if (value.configuration) {
+        args = args.concat(['--configuration', value.configuration]);
+    }
+    if (value.framework) {
+        args = args.concat(['--framework', value.framework]);
+    }
+    if (value.project) {
+        args = args.concat(['--project', value.project]);
+    }
+    if (value.runtime) {
+        args = args.concat(['--runtime', value.runtime]);
+    }    
+    if (value.launchProfile) {
+        args = args.concat(['--launch-profile', value.launchProfile]);
+    }    
+    if (value.noLaunchProfile) {
+        args = args.concat(['--no-launch-profile', value.noLaunchProfile]);
+    }    
+    if (value.noBuild) {
+        args = args.concat(['--no-build', value.noBuild]);
+    }    
+    if (value.noRestore) {
+        args = args.concat(['--no-restore', value.noRestore]);
+    }    
+    if (value.noDependencies) {
+        args = args.concat(['--no-dependencies', value.noDependencies]);
+    }    
+    if (value.force) {
+        args = args.concat(['--force', value.force]);
+    }        
+    if (value.verbosity) {
+        args = args.concat(['--verbosity', value.verbosity]);
+    }
+    if (value.msbuildArgs) {
+        args = args.concat(value.msbuildArgs);
+    }
+    if (value.version) {
+        args = args.concat(`/p:Version=${value.version}`);
+    }
+    return args;
+};
+
+module.exports = run;

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -1,0 +1,16 @@
+const Joi = require('joi');
+const shelly = require('./shelly');
+const argBuilder = require('./builders/cleanArgBuilder');
+const CleanModel = require('./models/CleanModel');
+const validation = Joi.object().keys(new CleanModel());
+
+module.exports = (options) => {
+    let {error, value} = Joi.validate(options || {}, validation);
+    if(error){
+        throw error;
+    }
+    let calculatedArgs = argBuilder(value);
+    
+    return shelly('dotnet', 'clean', calculatedArgs, value.echo);
+
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,5 +4,7 @@ module.exports = {
     test: require('./test'), 
     pack: require('./pack'), 
     publish: require('./publish'),
-    push: require('./push')
+    push: require('./push'),
+    clean: require('./clean'),
+    run: require('./clean')
 };

--- a/lib/models/BuildModel.js
+++ b/lib/models/BuildModel.js
@@ -11,7 +11,7 @@ class BuildModel {
         this.configuration = Joi.string().description('Configuration to use for building the project. Default for most projects is  "Debug"');
         this.versionSuffix = Joi.boolean().description('Defines the value for the $(VersionSuffix) property in the project');
         this.noIncremental = Joi.boolean().description('Disables incremental build.');
-        this.noDepenencies = Joi.boolean().description('Set this flag to ignore project-to-project references and only build the root project');
+        this.noDependencies = Joi.boolean().description('Set this flag to ignore project-to-project references and only build the root project');
         this.verbosity = Joi.string().only('quiet', 'minimal', 'normal', 'detailed', 'diagnostic');
         this.echo = Joi.boolean().default(false).description('Log the command to the console');
         this.version = Joi.string().description('Sets the $(Version) property in msbuild');

--- a/lib/models/CleanModel.js
+++ b/lib/models/CleanModel.js
@@ -1,0 +1,20 @@
+const Joi = require('joi');
+/* Represents a clean model */
+class CleanModel {
+  /**
+   * Create the validation model
+   */
+    constructor() {
+        this.output = Joi.string().description('Output directory in which to place built artifacts');
+        this.framework = Joi.string().description('Target framework to build for. The target framework has to be specified in the project file.');
+        this.runtime = Joi.string().description('Target runtime to build for. The default is to build a portable application.');
+        this.configuration = Joi.string().description('Configuration to use for building the project. Default for most projects is  "Debug"');
+        this.verbosity = Joi.string().only('quiet', 'minimal', 'normal', 'detailed', 'diagnostic');
+        this.echo = Joi.boolean().default(false).description('Log the command to the console');
+        this.version = Joi.string().description('Sets the $(Version) property in msbuild');
+        this.msbuildArgs = Joi.array().items(Joi.string()).description('Any extra options that should be passed to MSBuild. See dotnet msbuild -h for available options');
+    }
+
+}
+
+module.exports = CleanModel;

--- a/lib/models/RunModel.js
+++ b/lib/models/RunModel.js
@@ -1,0 +1,28 @@
+const Joi = require('joi');
+/* Represents a run model */
+class RunModel {
+  /**
+   * Create the validation model
+   */
+    constructor() {
+        this.configuration = Joi.string().description('Configuration to use for building the project. Default for most projects is  "Debug"');
+        this.framework = Joi.string().description('Target framework to build for. The target framework has to be specified in the project file.');
+        this.project = Joi.string().description('The path to the project file to run (defaults to the current directory if there is only one project).');
+        this.runtime = Joi.string().description('Target runtime to build for. The default is to build a portable application.');
+
+        this.launchProfile = Joi.string().description('The name of the launch profile (if any) to use when launching the application.');
+        this.noLaunchProfile = Joi.string().description('Do not attempt to use launchSettings.json to configure the application.');
+        this.noBuild = Joi.string().description('Skip building the project prior to running. By default, the project will be built.');
+        this.noRestore = Joi.string().description('Does not do an implicit restore when executing the command.');
+        this.noDependencies = Joi.string().description('Set this flag to ignore project to project references and only restore the root project.');
+        this.force = Joi.string().description('Set this flag to force all dependencies to be resolved even if the last restore was successful. This is equivalent to deleting project.assets.json.');
+        
+        this.verbosity = Joi.string().only('quiet', 'minimal', 'normal', 'detailed', 'diagnostic');
+        this.echo = Joi.boolean().default(false).description('Log the command to the console');
+        this.version = Joi.string().description('Sets the $(Version) property in msbuild');
+        this.msbuildArgs = Joi.array().items(Joi.string()).description('Any extra options that should be passed to MSBuild. See dotnet msbuild -h for available options');
+    }
+
+}
+
+module.exports = RunModel;

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,0 +1,16 @@
+const Joi = require('joi');
+const shelly = require('./shelly');
+const argBuilder = require('./builders/runArgBuilder');
+const runModel = require('./models/runModel');
+const validation = Joi.object().keys(new runModel());
+
+module.exports = (options) => {
+    let {error, value} = Joi.validate(options || {}, validation);
+    if(error){
+        throw error;
+    }
+    let calculatedArgs = argBuilder(value);
+    
+    return shelly('dotnet', ['run'], calculatedArgs, value.echo);
+
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3174 @@
+{
+  "name": "gulp-dotnet-cli",
+  "version": "0.4.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "beeper": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/beeper/-/beeper-1.1.1.tgz",
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "child-process-promise": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/child-process-promise/-/child-process-promise-2.2.1.tgz",
+      "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
+      "requires": {
+        "cross-spawn": "4.0.2",
+        "node-version": "1.1.0",
+        "promise-polyfill": "6.0.2"
+      }
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "clone": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/clone/-/clone-1.0.2.tgz",
+      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+    },
+    "clone-stats": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "coveralls": {
+      "version": "2.13.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/coveralls/-/coveralls-2.13.1.tgz",
+      "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "requires": {
+        "lru-cache": "4.1.1",
+        "which": "1.3.0"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        },
+        "entities": {
+          "version": "1.1.1",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/entities/-/entities-1.1.1.tgz",
+          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "requires": {
+        "readable-stream": "1.1.14"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fancy-log": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/fancy-log/-/fancy-log-1.3.0.tgz",
+      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "requires": {
+        "chalk": "1.1.3",
+        "time-stamp": "1.1.0"
+      }
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "glogg": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/glogg/-/glogg-1.0.0.tgz",
+      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "requires": {
+        "sparkles": "1.0.0"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "gulp-util": {
+      "version": "3.0.8",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/gulp-util/-/gulp-util-3.0.8.tgz",
+      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.0",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "requires": {
+        "glogg": "1.0.0"
+      }
+    },
+    "handlebars": {
+      "version": "4.0.10",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/handlebars/-/handlebars-4.0.10.tgz",
+      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.11.0",
+        "is-my-json-valid": "2.16.1",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "requires": {
+        "sparkles": "1.0.0"
+      }
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.3.0",
+        "domutils": "1.5.1",
+        "entities": "1.0.0",
+        "readable-stream": "1.1.14"
+      }
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.16.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha1-WoRnd+LCYg0eaRBOXToDsfYIjxE=",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "isemail": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/isemail/-/isemail-2.2.1.tgz",
+      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "istanbul": {
+      "version": "0.4.5",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.10",
+        "js-yaml": "3.6.1",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.3.0",
+        "wordwrap": "1.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "items": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/items/-/items-2.1.1.tgz",
+      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
+    },
+    "joi": {
+      "version": "10.6.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/joi/-/joi-10.6.0.tgz",
+      "integrity": "sha1-Ulh/AtUri3XNsMdPCxZKGRoOH8I=",
+      "requires": {
+        "hoek": "4.2.0",
+        "isemail": "2.2.1",
+        "items": "2.1.1",
+        "topo": "2.0.2"
+      }
+    },
+    "js-yaml": {
+      "version": "3.6.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.6.1.tgz",
+      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "2.7.3"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "jshint": {
+      "version": "2.9.5",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "dev": true,
+      "requires": {
+        "cli": "1.0.1",
+        "console-browserify": "1.1.0",
+        "exit": "0.1.2",
+        "htmlparser2": "3.8.3",
+        "lodash": "3.7.0",
+        "minimatch": "3.0.4",
+        "shelljs": "0.3.0",
+        "strip-json-comments": "1.0.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.7.0",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash/-/lodash-3.7.0.tgz",
+          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+          "dev": true
+        }
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash._reescape": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+    },
+    "lodash.template": {
+      "version": "3.6.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash.template/-/lodash.template-3.6.2.tgz",
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
+      }
+    },
+    "log-driver": {
+      "version": "1.2.5",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/log-driver/-/log-driver-1.2.5.tgz",
+      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "mocha-lcov-reporter": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz",
+      "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "multipipe": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "requires": {
+        "duplexer2": "0.0.2"
+      }
+    },
+    "node-version": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/node-version/-/node-version-1.1.0.tgz",
+      "integrity": "sha1-9DfXukB+ZeLE6u+Ih7Fxi6Uj1PA="
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
+    },
+    "nyc": {
+      "version": "10.3.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/nyc/-/nyc-10.3.2.tgz",
+      "integrity": "sha1-8n9NkfKp2zbCT1dP9cbv/wIz3kY=",
+      "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.0",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "1.1.2",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.1",
+        "istanbul-lib-coverage": "1.1.0",
+        "istanbul-lib-hook": "1.0.6",
+        "istanbul-lib-instrument": "1.7.1",
+        "istanbul-lib-report": "1.1.0",
+        "istanbul-lib-source-maps": "1.2.0",
+        "istanbul-reports": "1.1.0",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.0.3",
+        "micromatch": "2.3.11",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.1",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.2.4",
+        "test-exclude": "4.1.0",
+        "yargs": "7.1.0",
+        "yargs-parser": "5.0.0"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.0",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.0.3"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.1"
+          }
+        },
+        "babel-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.6",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.23.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.10.5"
+          }
+        },
+        "babel-template": {
+          "version": "6.24.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.24.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.22.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.0",
+            "debug": "2.6.6",
+            "globals": "9.17.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.24.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.17.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.0.2",
+            "which": "1.2.14"
+          }
+        },
+        "debug": {
+          "version": "2.6.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "0.7.3"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.6",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.3",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "globals": {
+          "version": "9.17.0",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.22"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.0"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.7.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.24.1",
+            "babel-template": "6.24.1",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.0",
+            "istanbul-lib-coverage": "1.1.0",
+            "semver": "5.3.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.1.0",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "2.6.6",
+            "istanbul-lib-coverage": "1.1.0",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1",
+            "source-map": "0.5.6"
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "4.0.8"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.1"
+          }
+        },
+        "lru-cache": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "merge-source-map": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.6"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.0",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "0.7.3",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.4.2",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.2",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          }
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "randomatic": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "kind-of": "3.2.0"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.3.8",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "bundled": true,
+          "dev": true
+        },
+        "regex-cache": {
+          "version": "0.4.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3",
+            "is-primitive": "2.0.0"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.1"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.1",
+            "signal-exit": "2.1.2",
+            "which": "1.2.14"
+          },
+          "dependencies": {
+            "signal-exit": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.22",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "which": {
+          "version": "1.2.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "promise-polyfill": {
+      "version": "6.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/promise-polyfill/-/promise-polyfill-6.0.2.tgz",
+      "integrity": "sha1-2chtPcTcLfkBboiUbe/Wm0m0EWI="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.3.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+    },
+    "request": {
+      "version": "2.79.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "qs": "6.3.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.4.3",
+        "uuid": "3.1.0"
+      }
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "sparkles": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/sparkles/-/sparkles-1.0.0.tgz",
+      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+    },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "vinyl": {
+      "version": "0.5.3",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/vinyl/-/vinyl-0.5.3.tgz",
+      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "requires": {
+        "clone": "1.0.2",
+        "clone-stats": "0.0.1",
+        "replace-ext": "0.0.1"
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/which/-/which-1.3.0.tgz",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://artifactory.adgr.net:8443/artifactory/api/npm/npm/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
+    }
+  }
+}

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -1,35 +1,41 @@
 let gulp = require('gulp');
-let {restore, build, test, pack, publish} = require('gulp-dotnet-cli');
+let { clean, restore, build, test, pack, publish, run } = require('../lib/index');
 let path = require('path');
 let process = require('process');
-let del = require('del');
 
-gulp.task('clean', ()=>{
-    return del(['**/obj', '**/bin']);
-})
-gulp.task('restore', ['clean'], ()=>{
-    return gulp.src('**/*.csproj', {read: false})
-            .pipe(restore({echo: true}));
-})
-
-gulp.task('build', ['restore'], ()=>{
-    return gulp.src('**/*.csproj', {read: false})
-        .pipe(build({configuration: 'Release', version: '1.3.0', echo: true}))
+gulp.task('clean', () => {
+    return gulp.src('**/*.csproj', { read: false })
+        .pipe(clean({ echo: true }));
 });
 
-gulp.task('test', ['build'], ()=>{
-    return gulp.src('tst/*.csproj', {read: false})
-        .pipe(test({echo: true}))
+gulp.task('restore', ['clean'], () => {
+    return gulp.src('**/*.csproj', { read: false })
+        .pipe(restore({ echo: true }));
 });
 
-gulp.task('publish', ['test'], ()=>{
-    return gulp.src('**/*.csproj', {read: false})
-                .pipe(publish())
-})
+gulp.task('build', ['restore'], () => {
+    return gulp.src('**/*.csproj', { read: false })
+        .pipe(build({ configuration: 'Release', version: '1.3.0', echo: true }));
+});
 
-gulp.task('pack', ['build'], ()=>{
-    return gulp.src('**/*.csproj', {read: false})
-                .pipe(pack({output: path.join(process.cwd(), 'nupkgs'), echo: true}))
-})
+gulp.task('test', ['build'], () => {
+    return gulp.src('tst/*.csproj', { read: false })
+        .pipe(test({ echo: true }));
+});
+
+gulp.task('publish', ['test'], () => {
+    return gulp.src('**/*.csproj', { read: false })
+        .pipe(publish());
+});
+
+gulp.task('run', () => {
+    return gulp.src('**/*.csproj', { read: false })
+        .pipe(run());
+});
+
+gulp.task('pack', ['build'], () => {
+    return gulp.src('**/*.csproj', { read: false })
+        .pipe(pack({ output: path.join(process.cwd(), 'nupkgs'), echo: true }));
+});
 
 gulp.task('preflight', ['restore', 'build', 'test', 'publish', 'pack']);

--- a/test/js/buildArgBuilder-test.js
+++ b/test/js/buildArgBuilder-test.js
@@ -28,8 +28,8 @@ describe('Build Argument Builder', () => {
     it('should have noIncremental if noIncremental is passed', () => {
       assert.deepEqual(builder({noIncremental: true}), ['--no-incremental']);
     });
-    it('should have noDepenencies if noDepenencies is passed', () => {
-      assert.deepEqual(builder({noDepenencies: true}), ['--no-dependencies']);
+    it('should have noDependencies if noDependencies is passed', () => {
+      assert.deepEqual(builder({noDependencies: true}), ['--no-dependencies']);
     });
     it('should have verbosity if verbosity is passed', () => {
       assert.deepEqual(builder({verbosity: 'yo'}), ['--verbosity', 'yo']);

--- a/test/js/cleanArgBuilder-test.js
+++ b/test/js/cleanArgBuilder-test.js
@@ -1,0 +1,34 @@
+let assert = require('assert');
+let builder = require('../../lib/builders/cleanArgBuilder');
+describe('Clean Argument Builder', () => {
+    it('should return an empty array if nothing is passed in', () => {
+      assert.deepEqual(builder(), []);
+    });
+    it('should return an empty array if an empty object is passed in', () => {
+      assert.deepEqual(builder({}), []);
+    });
+    it('should return an empty array if an array is passed in', () => {
+      assert.deepEqual(builder([]), []);
+    });
+    it('should have output if output is passed', () => {
+      assert.deepEqual(builder({output: 'yo'}), ['--output', 'yo']);
+    });
+    it('should have framework if framework is passed', () => {
+      assert.deepEqual(builder({framework: 'yo'}), ['--framework', 'yo']);
+    });
+    it('should have runtime if runtime is passed', () => {
+      assert.deepEqual(builder({runtime: 'yo'}), ['--runtime', 'yo']);
+    });   
+    it('should have configuration if configuration is passed', () => {
+      assert.deepEqual(builder({configuration: 'yo'}), ['--configuration', 'yo']);
+    });
+    it('should have verbosity if verbosity is passed', () => {
+      assert.deepEqual(builder({verbosity: 'yo'}), ['--verbosity', 'yo']);
+    });
+    it('should have msbuild args if msbuildargs are passed and are always last', () => {
+      assert.deepEqual(builder({msbuildArgs: ['/p:awesome=1.0.0', '/t:Build'], configuration: 'Release'}), ['--configuration','Release','/p:awesome=1.0.0', '/t:Build']);
+    });
+    it('should have msbuild args if msbuildargs are passed and are always last, version even...laster', () => {
+      assert.deepEqual(builder({msbuildArgs: ['/p:awesome=1.0.0', '/t:Build'], configuration: 'Release', version: '1.2.0'}), ['--configuration','Release','/p:awesome=1.0.0', '/t:Build', '/p:Version=1.2.0']);
+    });
+});

--- a/test/js/restoreArgBuilder-test.js
+++ b/test/js/restoreArgBuilder-test.js
@@ -31,8 +31,8 @@ describe('Restore Argument Builder', () => {
     it('should have noIncremental if noIncremental is passed', () => {
       assert.deepEqual(builder({noIncremental: true}), ['--no-incremental']);
     });
-    it('should have noDepenencies if noDepenencies is passed', () => {
-      assert.deepEqual(builder({noDepenencies: true}), ['--no-dependencies']);
+    it('should have noDependencies if noDependencies is passed', () => {
+      assert.deepEqual(builder({noDependencies: true}), ['--no-dependencies']);
     });
     it('should have msbuild args if msbuildargs are passed and are always last', () => {
       assert.deepEqual(builder({msbuildArgs: ['/p:awesome=1.0.0', '/t:Build']}), ['/p:awesome=1.0.0', '/t:Build']);

--- a/test/js/runArgBuilder-test.js
+++ b/test/js/runArgBuilder-test.js
@@ -1,0 +1,52 @@
+let assert = require('assert');
+let builder = require('../../lib/builders/runArgBuilder');
+describe('Run Argument Builder', () => {
+    it('should return an empty array if nothing is passed in', () => {
+      assert.deepEqual(builder(), []);
+    });
+    it('should return an empty array if an empty object is passed in', () => {
+      assert.deepEqual(builder({}), []);
+    });
+    it('should return an empty array if an array is passed in', () => {
+      assert.deepEqual(builder([]), []);
+    });
+    it('should have configuration if configuration is passed', () => {
+      assert.deepEqual(builder({configuration: 'yo'}), ['--configuration', 'yo']);
+    });    
+    it('should have framework if framework is passed', () => {
+      assert.deepEqual(builder({framework: 'yo'}), ['--framework', 'yo']);
+    });
+    it('should have project if project is passed', () => {
+      assert.deepEqual(builder({project: 'yo'}), ['--project', 'yo']);
+    });
+    it('should have runtime if runtime is passed', () => {
+      assert.deepEqual(builder({runtime: 'yo'}), ['--runtime', 'yo']);
+    });
+    it('should have launchProfile if launchProfile is passed', () => {
+      assert.deepEqual(builder({launchProfile: 'yo'}), ['--launch-profile', 'yo']);
+    });    
+    it('should have noLaunchProfile if noLaunchProfile is passed', () => {
+      assert.deepEqual(builder({noLaunchProfile: 'yo'}), ['--no-launch-profile', 'yo']);
+    });    
+    it('should have noBuild if noBuild is passed', () => {
+      assert.deepEqual(builder({noBuild: 'yo'}), ['--no-build', 'yo']);
+    });    
+    it('should have noRestore if noRestore is passed', () => {
+      assert.deepEqual(builder({noRestore: 'yo'}), ['--no-restore', 'yo']);
+    });    
+    it('should have noDependencies if noDependencies is passed', () => {
+      assert.deepEqual(builder({noDependencies: 'yo'}), ['--no-dependencies', 'yo']);
+    });    
+    it('should have force if force is passed', () => {
+      assert.deepEqual(builder({force: 'yo'}), ['--force', 'yo']);
+    });    
+    it('should have verbosity if verbosity is passed', () => {
+      assert.deepEqual(builder({verbosity: 'yo'}), ['--verbosity', 'yo']);
+    });
+    it('should have msbuild args if msbuildargs are passed and are always last', () => {
+      assert.deepEqual(builder({msbuildArgs: ['/p:awesome=1.0.0', '/t:Build'], configuration: 'Release'}), ['--configuration','Release','/p:awesome=1.0.0', '/t:Build']);
+    });
+    it('should have msbuild args if msbuildargs are passed and are always last, version even...laster', () => {
+      assert.deepEqual(builder({msbuildArgs: ['/p:awesome=1.0.0', '/t:Build'], configuration: 'Release', version: '1.2.0'}), ['--configuration','Release','/p:awesome=1.0.0', '/t:Build', '/p:Version=1.2.0']);
+    });
+});

--- a/test/package.json
+++ b/test/package.json
@@ -8,8 +8,7 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
-    "del": "^2.2.2",
+  "dependencies": {    
     "gulp": "^3.9.1",
     "gulp-dotnet-cli": "../",
     "joi": "^10.4.1"


### PR DESCRIPTION
added:
- run command
- clean command
- adjusted docs
- corrected noDepenencies to noDependencies typo

**User Story** (edited by [TerribleDev](https://github.com/terribledev))

As a user I'd like to use the builtin `dotnet clean` instead of importing del

* add a clean command which will call `dotnet clean [Project] [Options]`

example

```js
gulp.task('clean', ()=>{
    return gulp.src('**/*.csproj', {read: false})
               .pipe(clean({echo: true}));
})

gulp.task('build', ['clean'], ()=>{...});

```

OR:

```js
gulp.task('build', ()=>{
    return gulp.src('**/*.csproj', {read: false})
               .pipe(clean())
               .pipe(build());
})
```
As a user I'd like to use the builtin `dotnet run` command from gulp
* add a run command which will call `dotnet run [Project] [Options]`

example

```js
gulp.task('exec', ()=>{
    return gulp.src('**/*.csproj', {read: false})
               .pipe(run());
})

```




