### PR TITLE
add version to restore args

### DIFF
--- a/docs/restore.md
+++ b/docs/restore.md
@@ -84,3 +84,11 @@ The [restore model](/lib/models/RestoreModel.js) contains the actual model we va
 * default: false
 
 > Logs the command we run to the console
+
+#### version
+
+* type: `string`
+
+* default: false
+
+> Sets the projects version. When restore is ran project to project version numbers are resolved. This is only used for project to project references that will ultimately end up in separate packages.

--- a/lib/builders/restoreArgBuilder.js
+++ b/lib/builders/restoreArgBuilder.js
@@ -34,5 +34,8 @@ module.exports = (value) => {
     if (value.msbuildArgs) {
         args = args.concat(value.msbuildArgs);
     }
+    if (value.version) {
+        args = args.concat(`/p:Version=${value.version}`);
+    }
     return args;
 };

--- a/lib/models/RestoreModel.js
+++ b/lib/models/RestoreModel.js
@@ -13,6 +13,7 @@ class RestoreModel {
         this.echo = Joi.boolean().default(false).description('Log the command to the console');
         this.verbosity = Joi.string().only('quiet', 'minimal', 'normal', 'detailed', 'diagnostic');
         this.msbuildArgs = Joi.array().items(Joi.string()).description('Any extra options that should be passed to MSBuild. See dotnet msbuild -h for available options');
+        this.version = Joi.string().description('Sets the projects version. Only used for project to project references that will ultimately end up in packages');
     }
 }
 

--- a/test/js/restoreArgBuilder-test.js
+++ b/test/js/restoreArgBuilder-test.js
@@ -37,4 +37,7 @@ describe('Restore Argument Builder', () => {
     it('should have msbuild args if msbuildargs are passed and are always last', () => {
       assert.deepEqual(builder({msbuildArgs: ['/p:awesome=1.0.0', '/t:Build']}), ['/p:awesome=1.0.0', '/t:Build']);
     });
+    it('should version arguments', () => {
+      assert.deepEqual(builder({version: '1.0.1'}), ['/p:Version=1.0.1']);
+    });
 });


### PR DESCRIPTION
Sets the projects version. When restore is ran any project to project version numbers are resolved as nuget package references for a given version. This is only used for project to project references that will ultimately end up in separate packages.