### PR TITLE
emit errors to stream #27

### DIFF
--- a/src/declarations/child-process-promise.d.ts
+++ b/src/declarations/child-process-promise.d.ts
@@ -1,1 +1,3 @@
-declare module "child-process-promise";
+declare module "child-process-promise" {
+    export function spawn(command: string, arguments: string[], options: any): Promise<any>;
+}


### PR DESCRIPTION
Description: We should emit errors directly to the node stream.

User Story: As a user I want to call restore and build in the same vinyl stream, but if restore has issues the node stream should end prematurely.

Description of Change: Change arrow function in shelly to regular function so the `this` pinter is passed to us from the node stream. Emit an error directly into the node stream with `this.emit` [as documented by gulp](https://gulpjs.org/writing-a-plugin/dealing-with-streams)